### PR TITLE
Feature/empty default config

### DIFF
--- a/src/Middleware/LanguageSwitcherMiddleware.php
+++ b/src/Middleware/LanguageSwitcherMiddleware.php
@@ -26,9 +26,7 @@ class LanguageSwitcherMiddleware
             'expires' => '+1 year',
             'domain' => ''
         ],
-        'availableLanguages' => [
-            'en_US' => 'en_US'
-        ],
+        'availableLanguages' => [],
         'mappingFunction' => null
     ];
 

--- a/src/Middleware/LanguageSwitcherMiddleware.php
+++ b/src/Middleware/LanguageSwitcherMiddleware.php
@@ -28,7 +28,8 @@ class LanguageSwitcherMiddleware
         ],
         'availableLanguages' => [
             'en_US' => 'en_US'
-        ]
+        ],
+        'mappingFunction' => null
     ];
 
     /**
@@ -67,6 +68,13 @@ class LanguageSwitcherMiddleware
         if (isset($user)) {
             $usersTable = TableRegistry::get($this->config('model'));
             $user = $usersTable->get($user['id']);
+
+            $mappingFunction = $this->config('mappingFunction');
+            if (isset($mappingFunction)
+                && is_callable($mappingFunction)
+            ) {
+                $mappingFunction($user, $request, $response);
+            }
 
             if (!isset($user->{$this->config('field')})) {
                 $user->{$this->config('field')} = $cookieLocale;

--- a/src/View/Helper/LanguageSwitcherHelper.php
+++ b/src/View/Helper/LanguageSwitcherHelper.php
@@ -18,15 +18,9 @@ class LanguageSwitcherHelper extends Helper
     use InstanceConfigTrait;
 
     protected $_defaultConfig = [
-        'availableLanguages' => [
-            'en_US' => 'en_US'
-        ],
-        'displayNames' => [
-            'en_US' => 'English'
-        ],
-        'imageMapping' => [
-            'en_US' => 'United-States'
-        ]
+        'availableLanguages' => [],
+        'displayNames' => [],
+        'imageMapping' => []
     ];
 
     /**


### PR DESCRIPTION
Problem: the app config gets merged (Hash::merge in InstanceConfigTrait::_configWrite) with the default config from the plugin. 

Result: "en_US" from the plugin's default config will always appear in the lang switcher.

Solution: empty the default config.