### PR TITLE
Add better locale lookup

### DIFF
--- a/src/Middleware/LanguageSwitcherMiddleware.php
+++ b/src/Middleware/LanguageSwitcherMiddleware.php
@@ -119,6 +119,9 @@ class LanguageSwitcherMiddleware
         }
         if ($this->__getAllowedLanguages() !== ['*']) {
             $locale = Locale::lookup($this->__getAllowedLanguages(), $locale, true, Configure::read('App.defaultLocale'));
+            if ($locale === '') {
+                $locale = Configure::read('App.defaultLocale');
+            }
         }
         if ($locale || $this->__getAllowedLanguages() === ['*']) {
             $this->__setCookieAndLocale($locale);
@@ -166,10 +169,8 @@ class LanguageSwitcherMiddleware
         // @FIXME Should be refactored when cake 3.4 was released
         if (PHP_SAPI !== 'cli') {
             $time = $this->__getCookieExpireTime();
-            if (in_array($locale, $this->__getAllowedLanguages())) {
-                I18n::locale($locale);
-                setcookie($this->__getCookieName(), $locale, $time, '/', $this->config('Cookie.domain'));
-            }
+            I18n::locale($locale);
+            setcookie($this->__getCookieName(), $locale, $time, '/', $this->config('Cookie.domain'));
         }
     }
 

--- a/src/Middleware/LanguageSwitcherMiddleware.php
+++ b/src/Middleware/LanguageSwitcherMiddleware.php
@@ -117,11 +117,11 @@ class LanguageSwitcherMiddleware
         if (!$locale) {
             return $this->__next($request, $response, $next);
         }
-
-        if (in_array($locale, $this->__getAllowedLanguages()) || $this->__getAllowedLanguages() === ['*']) {
+        if ($this->__getAllowedLanguages() !== ['*']) {
+            $locale = Locale::lookup($this->__getAllowedLanguages(), $locale, true, Configure::read('App.defaultLocale'));
+        }
+        if ($locale || $this->__getAllowedLanguages() === ['*']) {
             $this->__setCookieAndLocale($locale);
-        } else {
-            $this->__setCookieAndLocale(Configure::read('App.defaultLocale'));
         }
 
         return $this->__next($request, $response, $next);


### PR DESCRIPTION
This allows us to set the app locale to `de` and we'll fallback to it, when `de_DE`, `de_AT` or `de_CH` will be present in the request header.