### PR TITLE
Make the cookie locale canonicalization configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ $middleware->push(new \LanguageSwitcher\Middleware\LanguageSwitcherMiddleware([
     'Cookie' => [
         'name' => 'ChoosenLanguage',
         'expires' => '+1 year',
-        'domain' => 'foo.bar'
+        'domain' => 'foo.bar',
+        'canonicalizeLocale' => false
     ],
     'availableLanguages' => [
         'en_US' => 'en_US'
@@ -94,7 +95,8 @@ Inside your app.php add the following to change configs of the plugin:
     'field' => 'language',
     'Cookie' => [
         'name' => 'ChoosenLanguage',
-        'expires' => '+1 year'
+        'expires' => '+1 year',
+        'canonicalizeLocale' => false
     ],
     'availableLanguages' => [
         'en_US'
@@ -115,7 +117,7 @@ Inside your app.php add the following to change configs of the plugin:
 
 - model: The model used in the migration
 - field: The field in the model
-- Cookie: Optionally you can change the cookie name and the expiration date of the cookie.
+- Cookie: Optionally you can change the cookie name, the expiration date of the cookie and define if the locale should be saved canonicalized.
 - availableLanguages: Add language keys
 - displayNames: Should contain the same keys as availableLanguages. Map language key with its Display Name
 - imageMapping: Should contain the same keys as availableLanguages. Map language key with its flag image name. (For all possible flag names open webroot/img/flags)

--- a/src/Middleware/LanguageSwitcherMiddleware.php
+++ b/src/Middleware/LanguageSwitcherMiddleware.php
@@ -24,7 +24,8 @@ class LanguageSwitcherMiddleware
         'Cookie' => [
             'name' => 'ChoosenLanguage',
             'expires' => '+1 year',
-            'domain' => ''
+            'domain' => '',
+            'canonicalizeLocale' => true
         ],
         'availableLanguages' => [
             'en_US' => 'en_US'
@@ -117,7 +118,7 @@ class LanguageSwitcherMiddleware
             return $this->__next($request, $response, $next);
         }
         if ($this->__getAllowedLanguages() !== ['*']) {
-            $locale = Locale::lookup($this->__getAllowedLanguages(), $locale, true, Configure::read('App.defaultLocale'));
+            $locale = Locale::lookup($this->__getAllowedLanguages(), $locale, $this->getConfig('Cookie.canonicalizeLocale'), Configure::read('App.defaultLocale'));
             if ($locale === '') {
                 $locale = Configure::read('App.defaultLocale');
             }


### PR DESCRIPTION
Currently the cookie locale will always be canonicalized, if no user exists in the session and the `choosen_language` cookie is set initially.

This results in following behaviour:
Even though we defined a set of `availableLanguages` the locale in the cookie will be set to `de_de`, since it is canonicalized. This cookie locale will be saved into the user entity as soon as the user logs into the website, which results into not translated localised string.

Example:
```
'availableLanguages' => [
            'de_DE' => 'de_DE',
],
```
-> The saved cookie will be `de_de`.